### PR TITLE
Refactor and make configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
-# neon-utterance-plugin-normalizer
+# Utterance Normalizer Plugin
 Normalizes utterances by stripping trailing punctuation, normalization (numeric substitutions, expanded contractions), and removing articles.
 Original utterances are preserved and returned utterances are returned in order:
 1. No Punctuation, Normalized
 2. No Punctuation, Normalized, Removed Articles
 3. No Punctuation
 4. Original Utterances
+
+## Configuration
+This plugin can be enabled and configured as described below. By default, all
+normalization is completed.
+
+```yaml
+utterance_transformers:
+  neon_utterance_normalizer_plugin:
+    remove_punctuation: True
+    remove_articles: False
+```

--- a/neon_utterance_normalizer_plugin/__init__.py
+++ b/neon_utterance_normalizer_plugin/__init__.py
@@ -37,7 +37,8 @@ from neon_transformers.tasks import UtteranceTask
 class UtteranceNormalizer(UtteranceTransformer):
     task = UtteranceTask.TRANSFORM
 
-    def __init__(self, name: str = "utterance_normalizer", priority: int = 1,
+    def __init__(self, name: str = "neon_utterance_normalizer_plugin",
+                 priority: int = 1,
                  config: Optional[dict] = None):
         super().__init__(name, priority, config)
         self.config_core = Configuration()

--- a/neon_utterance_normalizer_plugin/__init__.py
+++ b/neon_utterance_normalizer_plugin/__init__.py
@@ -28,6 +28,8 @@ import lingua_franca.config
 
 from typing import List, Optional
 from lingua_franca.parse import normalize
+from ovos_config import Configuration
+
 from neon_transformers import UtteranceTransformer
 from neon_transformers.tasks import UtteranceTask
 
@@ -35,21 +37,50 @@ from neon_transformers.tasks import UtteranceTask
 class UtteranceNormalizer(UtteranceTransformer):
     task = UtteranceTask.TRANSFORM
 
-    def __init__(self, name="utterance_normalizer", priority=1):
-        super().__init__(name, priority)
+    def __init__(self, name: str = "utterance_normalizer", priority: int = 1,
+                 config: Optional[dict] = None):
+        super().__init__(name, priority, config)
+        self.config_core = Configuration()
         lingua_franca.config.load_langs_on_demand = True
 
     def transform(self, utterances: List[str],
                   context: Optional[dict] = None) -> (list, dict):
+        """
+        Normalize and return an ordered list of utterances
+        @param utterances: List of utterances to be normalized
+        @param context: Utterance context (unused)
+        @returns: Ordered list of normalized + raw utterances, dict context
+        """
         context = context or {}
-        lang = context.get("lang") or self.config.get("lang", "en-us")
-        clean = [self._strip_punctuation(u) for u in utterances]
-        norm = [normalize(u, lang=lang, remove_articles=False) for u in clean]
-        norm2 = [normalize(u, lang=lang, remove_articles=True) for u in clean]
-        norm += [u for u in norm2 if u not in utterances and u not in norm]
-        norm += [u for u in clean if u not in utterances and u not in norm]
-        norm = [u for u in norm if u not in utterances]
-        return norm + utterances, {}
+        lang = context.get("lang") or self.config_core.get("lang", "en-us")
+        remove_punctuation = self.config.get("remove_punctuation", True)
+        remove_articles = self.config.get("remove_articles", True)
+        clean = []
+        norm = []
+        norm2 = []
+        for utt in utterances:
+            # Strip punctuation first and add NEW strings to clean
+            if remove_punctuation:
+                utt = self._strip_punctuation(utt)
+                if not any((utt in utterances, utt in clean)):
+                    clean.append(utt)
+
+            # Do basic normalization next and add NEW strings to norm
+            normal = normalize(utt, lang=lang, remove_articles=False)
+            if not any((normal in utterances, normal in norm)):
+                norm.append(normal)
+
+            # Remove articles and add NEW strings to norm2
+            if remove_articles:
+                normal = normalize(utt, lang=lang, remove_articles=True)
+                if normal not in utterances:
+                    norm2.append(normal)
+
+        # Append no-article normalization and punctuation cleaned to end of list
+        norm += [u for u in norm2 + clean if u not in norm]
+        return (norm + utterances,
+                {"normalization": {"remove_punctuation": remove_punctuation,
+                                   "remove_articles": remove_articles}})
 
     @staticmethod
     def _strip_punctuation(utterance: str):

--- a/tests/test_utterance_plugin.py
+++ b/tests/test_utterance_plugin.py
@@ -40,13 +40,15 @@ class TestUtterancePlugin(unittest.TestCase):
 
         # Contraction, article, and punctuation
         test_utterance = "what's a common name?"
-        utterances, _ = normalizer.transform([test_utterance])
+        utterances, meta = normalizer.transform([test_utterance])
         self.assertEqual(utterances, [
             "what is a common name",
             "what is common name",
             "what's a common name",
             "what's a common name?"
         ])
+        self.assertTrue(meta['normalization']['remove_punctuation'])
+        self.assertTrue(meta['normalization']['remove_articles'])
 
         # Multiple transcriptions
         test_utterances = ["what's your name", "what your name"]
@@ -56,6 +58,29 @@ class TestUtterancePlugin(unittest.TestCase):
             "what's your name",
             "what your name"
         ])
+
+        # Disable punctuation handling
+        normalizer.config['remove_punctuation'] = False
+        utterances, meta = normalizer.transform([test_utterance])
+        self.assertEqual(utterances, [
+            "what is a common name?",
+            "what is common name?",
+            "what's a common name?"
+        ])
+        self.assertFalse(meta['normalization']['remove_punctuation'])
+        self.assertTrue(meta['normalization']['remove_articles'])
+
+        # Disable article handling
+        normalizer.config['remove_punctuation'] = True
+        normalizer.config['remove_articles'] = False
+        utterances, meta = normalizer.transform([test_utterance])
+        self.assertEqual(utterances, [
+            "what is a common name",
+            "what's a common name",
+            "what's a common name?"
+        ])
+        self.assertTrue(meta['normalization']['remove_punctuation'])
+        self.assertFalse(meta['normalization']['remove_articles'])
 
     def test_strip_punctuation(self):
         self.assertEqual(UtteranceNormalizer._strip_punctuation('hello???'),


### PR DESCRIPTION
# Description
Add support for configuring normalization tasks
Add documentation
Return context describing normalization config

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
```
# Existing implementation
text_parsers:
  average: 0.066395
  maximum: 0.121224
  minimum: 0.036458
# Refactored with same execution
text_parsers:
  average: 0.051243
  maximum: 0.074595
  minimum: 0.025959
# With `remove_punctuation` and `remove_articles` disabled
text_parsers:
  average: 0.050677
  maximum: 0.079918
  minimum: 0.021769
```